### PR TITLE
Resolves #30, No error message provided for GriSets comparaison

### DIFF
--- a/src/main/java/org/opengeospatial/cite/wmts10/nsg/testsuite/getcapabilities/GetCapabilitiesWellKnownScaleTest.java
+++ b/src/main/java/org/opengeospatial/cite/wmts10/nsg/testsuite/getcapabilities/GetCapabilitiesWellKnownScaleTest.java
@@ -110,7 +110,9 @@ public class GetCapabilitiesWellKnownScaleTest extends AbstractBaseGetCapabiliti
             NodeList tileMatrixes = tileMatrixSet.getElementsByTagName( "TileMatrix" );
 
             if ( ( listFromAnnexB != null ) && ( listFromAnnexB.getLength() > 0 ) ) {
-                assertTrue( listFromAnnexB.getLength() >= tileMatrixes.getLength() );
+                assertTrue( listFromAnnexB.getLength() >= tileMatrixes.getLength(),
+                        String.format("Expected a grid set with %d levels but found %d levels.",
+                                listFromAnnexB.getLength(), tileMatrixes.getLength()));
 
                 int annexI = 0;
                 int tmsI = 0;


### PR DESCRIPTION
Associated issue https://github.com/opengeospatial/ets-wmts10-nsg/issues/30.