### PR TITLE
Set ets-dgiwg-core to v0.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
     <dependency>
       <groupId>de.latlon</groupId>
       <artifactId>ets-dgiwg-core</artifactId>
-      <version>0.3</version>
+      <version>0.5</version>
     </dependency>
     <dependency>
       <groupId>com.sun.jersey</groupId>


### PR DESCRIPTION
Can be merged as soon as ets-dgiwg-core v0.5 is released.